### PR TITLE
Version 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Option               | Type             | Default   | Description
 `protectsToShow`     | `string`,`array` | `all`     | One of: `all`, `first`, or an `array` with [device IDs](#list-view-with-id-thermostat--protect)
 `units`              | `string`         | config.js | One of: `imperial` (fahrenheit), `metric` (celsius)
 `updateInterval`     | `int`            | '60000'   | Nest recommends updating no more than once pr. minute.
+`initialLoadDelay`   | `int`            | '0'       | How long to delay the initial load (in ms)
 
 **Note:** `units` get their default value from the MagicMirror `config.js` file. I'd strongly suggest adding the value in there instead of adding it in this module.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Option               | Type             | Default   | Description
 `thermostatsToShow`  | `string`,`array` | `all`     | One of: `all`, `first`, or an `array` with [device IDs](#list-view-with-id-thermostat--protect)
 `protectsToShow`     | `string`,`array` | `all`     | One of: `all`, `first`, or an `array` with [device IDs](#list-view-with-id-thermostat--protect)
 `units`              | `string`         | config.js | One of: `imperial` (fahrenheit), `metric` (celsius)
-`updateInterval`     | `int`            | '60000'   | Nest recommends updating no more than once pr. minute.
+`updateInterval`     | `int`            | '120000'  | Default is 2 minutes - Nest recommends updating no more than once pr. minute.
 `initialLoadDelay`   | `int`            | '0'       | How long to delay the initial load (in ms)
 
 **Note:** `units` get their default value from the MagicMirror `config.js` file. I'd strongly suggest adding the value in there instead of adding it in this module.
@@ -196,6 +196,14 @@ If you don't own this font, this module will just fall back to using the standar
 ### Does this module support touch or mouse interactions? Eg. can I change the temperature of my thermostat using this?
 
 No, right now this module only displays information - it does not allow you to control your Nest devices.
+
+### I'm getting a "Nest API rate limit has been exceeded"-error - what does it mean?
+
+Nest applies data rate limits for accessing their API - if you get this error, it means your account has reached that limit and is now **temporarily** blocked from getting Nest API data. When this happens, the module will automatically try to load data again after **10 minutes**.
+
+There is, unfortunately, nothing you can do about this - you simply have to wait for their block to expire.
+
+You can [read more here](https://developers.nest.com/guides/api/data-rate-limits).
 
 ## Using Handlebars
 

--- a/mmm-nest-status.css
+++ b/mmm-nest-status.css
@@ -211,6 +211,7 @@
     text-overflow: ellipsis;
     margin: 0;
     padding-bottom: 15px;
+    text-align: center;
 }
 
 .mmm-nest-status .size-large .title {

--- a/mmm-nest-status.js
+++ b/mmm-nest-status.js
@@ -29,7 +29,7 @@ Module.register('mmm-nest-status', {
         updateInterval: 60 * 1000,
         animationSpeed: 2 * 1000,
         initialLoadDelay: 0,
-        version: '1.2.0'
+        version: '1.2.1'
     },
 
     getScripts: function() {

--- a/mmm-nest-status.js
+++ b/mmm-nest-status.js
@@ -26,7 +26,7 @@ Module.register('mmm-nest-status', {
         protectDark: false,
         protectShowOk: true,
         units: config.units,
-        updateInterval: 60 * 1000,
+        updateInterval: 120 * 1000,
         animationSpeed: 2 * 1000,
         initialLoadDelay: 0,
         version: '1.2.1'
@@ -57,11 +57,7 @@ Module.register('mmm-nest-status', {
         }
 
         this.errMsg = '';
-
         this.loaded = false;
-
-
-        this.scheduleUpdate(this.config.initialLoadDelay);
 
         this.thermostats = [];
         this.protects = [];
@@ -507,17 +503,81 @@ Module.register('mmm-nest-status', {
 
     },
 
+    notificationReceived(notification, payload, sender) {
+
+        /*
+            In case we have multiple `mmm-nest-status` modules with the same token running, we'll use just one
+            data stream to update all modules.
+        */
+
+        if (notification === 'ALL_MODULES_STARTED') {
+
+            // check if multiple `mmm-nest-status` modules are installed
+            var nestStatusModules = MM.getModules().withClass('mmm-nest-status');
+            var nestStatusModulesNum = nestStatusModules.length;
+
+            var token = this.config.token;
+            var identifier = this.identifier;
+            var tokensMatch = true;
+            var nestTransmitter = false; // whether this is the instance that should transmit data
+
+            if (nestStatusModulesNum > 1) {
+
+                // yep, we have more than one instance
+                // let's see if their tokens match
+                for (i = 0; i < nestStatusModulesNum; i++) {
+
+                    if ((i < 1) && (identifier === nestStatusModules[i].data.identifier)) {
+                        // this is the first instance of this module
+                        nestTransmitter = true;
+                    }
+
+                    if (token !== nestStatusModules[i].config.token) {
+                        // no match on tokens, unfortunately
+                        tokensMatch = false;
+                    }
+
+                }
+
+                if (tokensMatch && nestTransmitter) {
+                    // this is the instance that should be transmitting data
+                    this.scheduleUpdate(this.config.initialLoadDelay);
+                }
+
+            } else {
+                // there is only mmm-nest-status module instance or the tokens didn't
+                // match between instances
+                this.scheduleUpdate(this.config.initialLoadDelay);
+            }
+
+        } else if (notification === 'MMM_NEST_STATUS_UPDATE') {
+            // use the data from another `mmm-nest-status` module
+            this.processNestData(payload);
+        }
+    },
+
     socketNotificationReceived: function(notification, payload) {
+
+        var self = this;
 
         if (notification === 'MMM_NEST_STATUS_DATA') {
             // broadcast Nest data update
-            this.sendNotification('MMM_NEST_STATUS_UPDATE', payload);
+            self.sendNotification('MMM_NEST_STATUS_UPDATE', payload);
             // process the data
-            this.processNestData(payload);
-            this.scheduleUpdate(this.config.updateInterval);
+            self.processNestData(payload);
+            self.scheduleUpdate(self.config.updateInterval);
         } else if (notification === 'MMM_NEST_STATUS_DATA_ERROR') {
-            this.errMsg = 'Nest API Error: ' + payload;
-            this.updateDom(this.config.animationSpeed);
+            self.errMsg = 'Nest API Error: ' + payload;
+            self.updateDom(self.config.animationSpeed);
+        } else if (notification === 'MMM_NEST_STATUS_DATA_BLOCKED') {
+            // this is a specific error that occurs when the Nest API rate limit has been exceeded.
+            // https://developers.nest.com/guides/api/data-rate-limits
+            // we'll try again after 10 minutes
+            setTimeout(function() {
+                self.scheduleUpdate(self.config.updateInterval);
+            }, 10 * 60 * 1000);
+            self.errMsg = 'The Nest API rate limit has been exceeded.<br>This module will try to load data again in 10 minutes.';
+            self.updateDom(self.config.animationSpeed);
         }
 
     },

--- a/mmm-nest-status.js
+++ b/mmm-nest-status.js
@@ -29,7 +29,7 @@ Module.register('mmm-nest-status', {
         updateInterval: 120 * 1000,
         animationSpeed: 2 * 1000,
         initialLoadDelay: 0,
-        version: '1.2.1'
+        version: '1.3.0'
     },
 
     getScripts: function() {

--- a/node_helper.js
+++ b/node_helper.js
@@ -17,7 +17,9 @@ module.exports = NodeHelper.create({
 
             request(url, {method: 'GET'}, function(err, res, body) {
 
-                if ((err) || (res.statusCode !== 200)) {
+                if (res.statusCode === 429) {
+                    self.sendSocketNotification('MMM_NEST_STATUS_DATA_BLOCKED', err);
+                } else if ((err) || (res.statusCode !== 200)) {
                     self.sendSocketNotification('MMM_NEST_STATUS_DATA_ERROR', err);
                 } else {
                     if (body === {}) {


### PR DESCRIPTION
- add `initialLoadDelay` to read me (the option has always been there, just wasn't documented)
- small css fix so `alignment` only applies to containers, not the text inside containers
- switch default `updateInterval` to be 2 minutes (instead of 1)
- add a smarter socket listener, so multiple instances of `mmm-nest-status` all get their data from just one source
- add error message for when the Nest api rate limit has been exceeded and no data is returned