### PR TITLE
Use Google Device Access instead of Nest developer API

### DIFF
--- a/ACCESS_TOKENS.md
+++ b/ACCESS_TOKENS.md
@@ -1,7 +1,7 @@
 # Access Keys & Tokens for mmm-nest-status
 
 ## Which Keys & Tokens Do I Need?
-You'll need 4 of them:
+You'll need these 4:
 - Google Cloud Platform OAuth 2.0 Client ID
 - Google Cloud Platform OAuth 2.0 Client Secret
 - Device Access Project ID
@@ -11,7 +11,40 @@ You'll need 4 of them:
 
 Well, the easiest way is to simply follow Google's [Device Access Quick Start Guide](https://developers.google.com/nest/device-access/get-started). You will, of course, need a Google acount in order to do so.
 
-More stuff here ...
+If you go through Step 1 (Get Started) and Step 2 (Authorize an Account), it should provide you with the necessary keys and tokens.
+
+## Is This a Difficult Process? Can You Help?
+
+It really depends on your technical knowledge & skill level. I'm fairly tech-savvy and there were still a couple of areas during the process I felt a bit stumped.
+
+With that said, here are the steps I took in order to get this working on my own mirrors:
+
+1. Register for Device Access in the [Device Access Console](https://console.nest.google.com/device-access). You'll need to pay a one-time fee of $5.
+2. Enable the API & get an OAuth 2.0 Client ID for a Google Cloud Platform project
+  - I'd suggest using the `Enable the API and get an OAuth 2.0 Client ID` button that's on the `Get Started` page of the Quick Start Guide I linked above - it's much easier than doing it inside the Google Cloud Console.
+  - Make sure to choose `Web Server` when it asks "Where are you calling from?" and to enter `https://www.google.com` as the value for Authorized redirect URIs. If you don't, the next step will fail.
+  - Save the `OAuth Client ID` and `OAuth Client Secret` values for later - you'll need them for the main `config.js` file in your MagicMirror installation and also to get the refresh token.
+3. Go to the [Device Access Console](https://console.nest.google.com/device-access) and create a new project.
+  - Pick a name (doesn't really matter what it is), then add the `OAuth Client ID` that was generated in the previous step.
+  - I don't use Events in this module, so whether you enable/disable them is up to you.
+  - Once you're done, you'll get a `Project ID` which you'll add to the the main `config.js` file in your MagicMirror installation.
+4. Link your account using the instructions on the [Authorize an Account page](https://developers.google.com/nest/device-access/authorize).
+  - Make sure you're using the `Project ID` you just generated and the `OAuth Client ID` from Step 2 above.
+  - I would suggest you enable **all** permissions for **all** devices (saves you from having to do this again if you're also using my `mmm-nest-cameras` module), but, technically, you only need to enable access to your thermostats in order for this module to work.
+  - Once you've confirmed your choices, you'll be redirected to `google.com` and your URL will contain an `authorization code` you'll need for the next (and final) step. Make sure to copy that code before navigating away from that page.
+5. Get an access token using the instructions on the [Authorize an Account page](https://developers.google.com/nest/device-access/authorize).
+  - You can either do this in your `terminal` using curl (as the example shows on the page) or use a dedicated REST client like [Postman](https://www.postman.com).
+  - If everything goes according to plan, you should get a JSON response that contains both an `access_token` and a `refresh_token`. This module only uses the `refresh_token`, so feel free to ignore everything else.
+
+That's it - you should now have:
+- Google Cloud Platform OAuth 2.0 Client ID from Step 2
+- Google Cloud Platform OAuth 2.0 Client Secret from Step 2
+- Device Access Project ID from Step 3
+- Device Access Refresh Token from Step 4
+
+Add them to the `config.js` file in your MagicMirror installation and you should be good to go:
+
+![image](https://user-images.githubusercontent.com/3209660/144290713-c4b0d3cb-68bc-4a66-912b-0887f1e3793a.png)
 
 ## Can I Use My Old Nest Developer Account With This Module?
 

--- a/ACCESS_TOKENS.md
+++ b/ACCESS_TOKENS.md
@@ -1,0 +1,20 @@
+# Access Keys & Tokens for mmm-nest-status
+
+## Which Keys & Tokens Do I Need?
+You'll need 4 of them:
+- Google Cloud Platform OAuth 2.0 Client ID
+- Google Cloud Platform OAuth 2.0 Client Secret
+- Device Access Project ID
+- Device Access Refresh Token
+
+## So ... How Do I Get Them?
+
+Well, the easiest way is to simply follow Google's [Device Access Quick Start Guide](https://developers.google.com/nest/device-access/get-started). You will, of course, need a Google acount in order to do so.
+
+More stuff here ...
+
+## Can I Use My Old Nest Developer Account With This Module?
+
+The 2.x version of this module **only** supports the [Google Device Access API](https://developers.google.com/nest/device-access).
+
+If you still have an old Nest developer account, you'll need to either migrate it to Google or use the [`1.4.3`](https://github.com/michael5r/mmm-nest-status/tree/1.4.3) version of this module.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Module: mmm-nest-status
 
-## Important Note About the Nest API
-Due to Google closing down the `Works with Nest`-program, the only people who can currently use this module are the ones that already have a non-migrated Nest API account (there is no way to create a new Nest API account anymore).
+## About the API
+Please note that v2.x of this module *only* supports the Google Device Access API.
 
-When Google launches their [`Device Access`](https://developers.google.com/nest/device-access) program in 2020, I'll hopefully be able to update this module to use that API instead, but right now there's nothing I can do about this, unfortunately.
+If you still have an old Nest developer account, you'll need to either migrate it to Google or use the [`1.4.3`](https://github.com/michael5r/mmm-nest-status/tree/1.4.3) version of this module.
 
 ## About This Module
 
 The `mmm-nest-status` module is a [MagicMirror](https://github.com/MichMich/MagicMirror) addon.
 This module requires MagicMirror version `2.5` or later.
 
-This module displays both your [Nest](https://www.nest.com) thermostats and protect smoke detectors on your Magic Mirror and supports multiple modes to get you exactly the views that you want.
+This module displays your [Nest](https://www.nest.com) thermostats on your Magic Mirror and supports multiple modes to get you exactly the views that you want.
 
 ![image](https://user-images.githubusercontent.com/3209660/49621016-097fb400-f989-11e8-9fb2-bb824ac41203.png)
 *An example showing multiple thermostats and multiple smoke detectors (using the large size & classic mode for the thermostats, and the small size & dark mode for the protects)*
@@ -18,11 +18,9 @@ This module displays both your [Nest](https://www.nest.com) thermostats and prot
 
 ## Key Features
 - all states for the Nest thermostat (including Eco mode, Away mode, leaf/fan icons, etc) in 2 different designs and 3 sizes
-- all states for the Nest protect in 2 different designs and 3 sizes
 - 2 different modes - `grid` and `list` - allows you to easily customize your display
-- choose to display all of your thermostats/protects, or pick & choose which devices to show
-- choose to display the name of the thermostat/protect for easy identification
-- group the thermostats and protects together, or split them up into stackable containers
+- choose to display all of your thermostats, or pick & choose which devices to show
+- choose to display the name of the thermostat for easy identification
 - only re-renders the devices when data has actually changed
 
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This module displays your [Nest](https://www.nest.com) thermostats on your Magic
 - [Using the module](#using-the-module)
 - [General Configuration Options](#general-configuration-options)
 - [Configuration Options specific to the Grid view](#configuration-options-specific-to-the-grid-view)
-- [How To Get the Access Tokens](#how-to-get-the-access-tokens)
+- [How To Get the Access Tokens & Keys](#how-to-get-the-access-tokens-and-keys)
 - [How It Looks](#how-it-looks)
   * [Grid view (Classic Mode)](#grid-view-classic-mode)
   * [Grid view (Non-Classic Mode)](#grid-view-non-classic-mode)
@@ -109,9 +109,9 @@ Option               | Type             | Default   | Description
 `thermostatClassic`  | `boolean`        | `true`    | [Classic view](#grid-view-thermostat-classic-mode) of the thermostat
 
 
-## How To Get the Access Tokens
+## How To Get the Access Tokens and Keys
 
-Compared to the old Nest developer API, working with Google Device Access to get your access tokens is, well, to put it mildly, a fair bit more cumbersome.
+Compared to the old Nest developer API, working with Google Device Access to get your access tokens & keys is, well, to put it mildly, a fair bit more cumbersome.
 
 In order for this module to work, you'll need 4 things:
 - Google Cloud Platform OAuth 2.0 Client ID
@@ -119,7 +119,7 @@ In order for this module to work, you'll need 4 things:
 - Device Access Project ID
 - Device Access Refresh Token
 
-I've put together a document that tells you how to do this - you can find it here.
+I've put together a document that tells you how to do this - [you can find it here](ACCESS_TOKENS.md).
 
 
 ## How It Looks

--- a/mmm-nest-dial.js
+++ b/mmm-nest-dial.js
@@ -67,12 +67,11 @@ var mmmNestDial = (function() {
             maxValue: (options.temperatureScale === 'F') ? 90 : 30,
             hasLeaf: options.hasLeaf || false,
             targetTemp: options.targetTemp ? restrictTargetTemperature(+options.targetTemp) : options.minValue,
-            targetTempLow: options.targetTempLow || options.minValue,
-            targetTempHigh: options.targetTempHigh || options.maxValue,
+            targetTempCool: options.targetTempCool || options.minValue,
+            targetTempHeat: options.targetTempHeat || options.maxValue,
             ambientTemp: options.ambientTemp ? roundHalf(+options.ambientTemp) : options.minValue,
             ecoTempLow: options.ecoTempLow || options.minValue,
             ecoTempHigh: options.ecoTempHigh || options.maxValue,
-            isAwayMode: options.isAwayMode || false,
             isEcoMode: options.isEcoMode || false,
             isOffMode: options.isOffMode || false,
             isHeatCoolMode: options.isHeatCoolMode || false
@@ -298,7 +297,7 @@ var mmmNestDial = (function() {
         };
 
         // leaf SVG
-        if ((options.hasLeaf) && (!options.isAwayMode)) {
+        if (options.hasLeaf) {
             var leafScale = properties.radius/5/100;
             var leafDef = ["M", 3, 84, "c", 24, 17, 51, 18, 73, -6, "C", 100, 52, 100, 22, 100, 4, "c", -13, 15, -37, 9, -70, 19, "C", 4, 32, 0, 63, 0, 76, "c", 6, -7, 18, -17, 33, -23, 24, -9, 34, -9, 48, -20, -9, 10, -20, 16, -43, 24, "C", 22, 63, 8, 78, 3, 84, "z"].map(function(x) {
                 return isNaN(x) ? x : x * leafScale;
@@ -320,9 +319,9 @@ var mmmNestDial = (function() {
                 vMin = options.ecoTempLow;
                 vMax = options.ecoTempHigh;
             } else if (options.isHeatCoolMode) {
-                vMin = options.targetTempLow;
-                vMax = options.targetTempHigh;
-            } else if ((options.isAwayMode) || (options.isOffMode)) {
+                vMin = options.targetTempCool;
+                vMax = options.targetTempHeat;
+            } else if (options.isOffMode) {
                 vMin = options.ambientTemp;
                 vMax = vMin;
             } else {

--- a/mmm-nest-status.css
+++ b/mmm-nest-status.css
@@ -260,8 +260,8 @@
 /*
     GRID VIEW: THERMOSTAT
     Thermostat gets one class from each of the following groups:
-    - heating, cooling (from hvacState)
-    - heat, cool, heat-cool, eco, off (from hvacMode)
+    - heating, cooling, off (from thermostatHvac)
+    - heat, cool, heatcool, off (from thermostatMode)
     - size-large, size-medium, size-small (from thermostatSize)
 */
 
@@ -442,13 +442,13 @@
     padding-bottom: 0.4em;
 }
 
-.mmm-nest-status .thermostat.heat-cool .temp {
+.mmm-nest-status .thermostat.heatcool .temp {
     font-size: 0.8em;
     color: #aaa;
     flex-direction: row;
 }
 
-.mmm-nest-status .thermostat.heat-cool .temp-status {
+.mmm-nest-status .thermostat.heatcool .temp-status {
     display: none;
 }
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -7,32 +7,113 @@ module.exports = NodeHelper.create({
         console.log('Starting node_helper for module [' + this.name + ']');
     },
 
+    getDeviceData: function(dataUrl, dataOptions, tokenData) {
+
+        var self = this;
+
+        request(dataUrl, dataOptions, function(err, res, body) {
+
+            if ((res.statusCode === 401) && (res.statusMessage === 'Unauthorized')) {
+                // access token has expired
+                self.sendSocketNotification('MMM_NEST_STATUS_ACCESS_EXPIRED', tokenData);
+            } else if (res.statusCode === 429) {
+                self.sendSocketNotification('MMM_NEST_STATUS_DATA_BLOCKED', err);
+            } else if ((err) || (res.statusCode !== 200)) {
+                self.sendSocketNotification('MMM_NEST_STATUS_DATA_ERROR', err);
+            } else {
+                if (body === {}) {
+                    self.sendSocketNotification('MMM_NEST_STATUS_DATA_ERROR', 'Token works, but no data was received.<br>Make sure you are using the master account for your Nest.');
+                } else {
+                    var data = JSON.parse(body);
+                    data.tokenData = tokenData;
+                    self.sendSocketNotification('MMM_NEST_STATUS_DATA', data);
+                }
+            }
+
+        });
+
+    },
+
     socketNotificationReceived: function(notification, payload) {
 
         if (notification === 'MMM_NEST_STATUS_GET') {
 
-            var token = payload.token;
-            var url = 'https://developer-api.nest.com/?auth=' + token;
             var self = this;
+            var clientId = payload.clientId;
+            var clientSecret = payload.clientSecret;
+            var refreshToken = payload.refreshToken;
+            var projectId = payload.projectId;
+            var tokenData = payload.tokenData;
 
-            request(url, {method: 'GET'}, function(err, res, body) {
+            var dataUrl = 'https://smartdevicemanagement.googleapis.com/v1/enterprises/' + projectId + '/devices';
+            var dataOptions = {};
 
-                if (res.statusCode === 429) {
-                    self.sendSocketNotification('MMM_NEST_STATUS_DATA_BLOCKED', err);
-                } else if ((err) || (res.statusCode !== 200)) {
-                    self.sendSocketNotification('MMM_NEST_STATUS_DATA_ERROR', err);
-                } else {
-                    if (body === {}) {
-                        self.sendSocketNotification('MMM_NEST_STATUS_DATA_ERROR', 'Token works, but no data was received.<br>Make sure you are using the master account for your Nest.');
-                    } else {
-                        var data = JSON.parse(body);
-                        self.sendSocketNotification('MMM_NEST_STATUS_DATA', data);
-                    }
+            var refreshUrl = 'https://www.googleapis.com/oauth2/v4/token?client_id=' + clientId + '&client_secret=' + clientSecret + '&refresh_token=' + refreshToken + '&grant_type=refresh_token';
+            var refreshOptions = {
+                'method': 'POST'
+            };
+
+            // the access token expires after an hour, so there's really no reason to update it every time
+            // we want to refresh the Nest data
+
+            // there are three scenarios:
+            // 1. we have token data, and the access token is still valid
+            // 2. we have token data, but the access token has expired
+            // 3. we have no token data and therefore no access token
+
+            var tokenStillValid = false;
+            var currentTimeInSeconds = new Date().getTime() / 1000;
+
+            if ((tokenData) && (tokenData.access_token) && (tokenData.expires_in_time)) {
+                // check to see if access token has more than 5 mins of expiry time left
+                if (tokenData.expires_in_time > (300 + currentTimeInSeconds)) {
+                    tokenStillValid = true;
                 }
+            }
 
-            });
+            if (tokenStillValid) {
+                // token is still valid, so no need to get a new one
 
+                dataOptions = {
+                    'method': 'GET',
+                    headers: {
+                        'Authorization': 'Bearer ' + tokenData.access_token,
+                        'Content-Type': 'application/json'
+                    }
+                };
+
+                self.getDeviceData(dataUrl, dataOptions, tokenData);
+
+            } else if (!tokenStillValid || !tokenData || (tokenData && Object.keys(tokenData).length === 0)) {
+                // token is either expired or we have no token data, so time to use the refresh token
+                // to get a new access token
+
+                request(refreshUrl, refreshOptions, function(err, res, body) {
+                    var bodyData = JSON.parse(body);
+
+                    if (bodyData && bodyData.access_token) {
+
+                        tokenData = bodyData;
+                        tokenData.refresh_token = refreshToken;
+                        tokenData.expires_in_time = currentTimeInSeconds + bodyData.expires_in;
+
+                        dataOptions = {
+                            'method': 'GET',
+                            headers: {
+                                'Authorization': 'Bearer ' + tokenData.access_token,
+                                'Content-Type': 'application/json'
+                            }
+                        };
+
+                        self.getDeviceData(dataUrl, dataOptions, tokenData);
+
+                    } else {
+                        // don't know how you'd get here
+                        self.sendSocketNotification('MMM_NEST_STATUS_DATA_ERROR', 'Authentication failed.<br>Please double-check that your refresh token is correct and try again in a minute or two.');
+                    }
+                });
+
+            }
         }
     }
-
 });


### PR DESCRIPTION
This version updates the module to use Google Device Access instead of the deprecated Nest developer API.

Please note that `Device Access` does not support getting data from Nest Protects, so this module will only display the Nest thermostats in this version. Hopefully, this is something that they'll update at some point.