### PR TITLE
Add reloading on data timeout & better error messaging

### DIFF
--- a/mmm-nest-status.js
+++ b/mmm-nest-status.js
@@ -603,7 +603,6 @@ Module.register('mmm-nest-status', {
             self.config.tokenData = payload.tokenData;
             self.processNestData(payload);
             self.scheduleUpdate(self.config.updateInterval);
-            console.log('GOT DATA JUST FINE from mmm-nest-status');
         } else if (notification === 'MMM_NEST_STATUS_ACCESS_EXPIRED') {
             // the access token has expired
             // so we get the data again, but this time we add the old token data

--- a/mmm-nest-status.js
+++ b/mmm-nest-status.js
@@ -603,6 +603,7 @@ Module.register('mmm-nest-status', {
             self.config.tokenData = payload.tokenData;
             self.processNestData(payload);
             self.scheduleUpdate(self.config.updateInterval);
+            console.log('GOT DATA JUST FINE from mmm-nest-status');
         } else if (notification === 'MMM_NEST_STATUS_ACCESS_EXPIRED') {
             // the access token has expired
             // so we get the data again, but this time we add the old token data
@@ -616,13 +617,18 @@ Module.register('mmm-nest-status', {
         } else if (notification === 'MMM_NEST_STATUS_DATA_ERROR') {
             self.errMsg = 'Nest API Error: ' + payload;
             self.updateDom(self.config.animationSpeed);
+        } else if (notification === 'MMM_NEST_STATUS_DATA_TIMEOUT_ERROR') {
+            self.scheduleUpdate(5 * 60 * 1000); // try loading the data again after 5 minutes
+            if (!self.loaded) {
+                // if no data has been loaded, we'll show the error message
+                self.errMsg = 'Nest API Timeout Error: ' + payload + '<br>This module will try to load data again in 5 minutes.';
+                self.updateDom(self.config.animationSpeed);
+            }
         } else if (notification === 'MMM_NEST_STATUS_DATA_BLOCKED') {
             // this is a specific error that occurs when the API rate limit has been exceeded.
             // https://developers.google.com/nest/device-access/reference/errors/api
             // we'll try again after 10 minutes
-            setTimeout(function() {
-                self.scheduleUpdate(self.config.updateInterval);
-            }, 10 * 60 * 1000);
+            self.scheduleUpdate(10 * 60 * 1000);
             self.errMsg = 'The Device Access API rate limit has been exceeded.<br>This module will try to load data again in 10 minutes.';
             self.updateDom(self.config.animationSpeed);
         }

--- a/node_helper.js
+++ b/node_helper.js
@@ -7,6 +7,10 @@ module.exports = NodeHelper.create({
         console.log('Starting node_helper for module [' + this.name + ']');
     },
 
+    cleanErrorMessage: function(err) {
+        return err && err.message ? err.message : JSON.stringify(err);
+    },
+
     getDeviceData: function(dataOptions, tokenData) {
 
         var self = this;
@@ -18,9 +22,9 @@ module.exports = NodeHelper.create({
                     // access token has expired
                     self.sendSocketNotification('MMM_NEST_STATUS_ACCESS_EXPIRED', tokenData);
                 } else if (res.status === 429) {
-                    self.sendSocketNotification('MMM_NEST_STATUS_DATA_BLOCKED', err);
+                    self.sendSocketNotification('MMM_NEST_STATUS_DATA_BLOCKED', self.cleanErrorMessage(err));
                 } else if (res.status !== 200) {
-                    self.sendSocketNotification('MMM_NEST_STATUS_DATA_ERROR', err);
+                    self.sendSocketNotification('MMM_NEST_STATUS_DATA_ERROR', self.cleanErrorMessage(err));
                 } else {
                     if (res.data === {}) {
                         self.sendSocketNotification('MMM_NEST_STATUS_DATA_ERROR', 'Token works, but no data was received.<br>Make sure you are using the master account for your Nest.');
@@ -33,7 +37,8 @@ module.exports = NodeHelper.create({
 
             })
             .catch(function (err) {
-                self.sendSocketNotification('MMM_NEST_STATUS_DATA_ERROR', err);
+                // if you're here, this is most likely due to a timeout connecting to Google
+                self.sendSocketNotification('MMM_NEST_STATUS_DATA_TIMEOUT_ERROR', self.cleanErrorMessage(err));
             });
 
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mmm-nest-status",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmm-nest-status",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Display Nest Thermostat data on your MagicMirror. Supports multiple modes, sizes & views to get you exactly the look you want.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- when there's a timeout error connecting to the Google API, the module will automatically try to load data again after 5 minutes
- added better error messaging:

![image](https://user-images.githubusercontent.com/3209660/160178344-7ba22c89-687e-40ce-83fd-8f4a55e39ef1.png)

Should help with this issue:
https://github.com/michael5r/mmm-nest-status/issues/22